### PR TITLE
Option for persisting notifications in the Action Center

### DIFF
--- a/toast.go
+++ b/toast.go
@@ -120,13 +120,15 @@ func (n *Notification) buildXML() (string, error) {
 //         log.Fatalln(err)
 //     }
 func (n *Notification) Push() error {
-	// Create a key for the AppID's persistence setting.
-	k, _, _ := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\`+n.AppID, registry.ALL_ACCESS)
-	// Set the correct registry value.
-	dwval := uint32(0)
-	if n.Persist {dwval = 1}
-	k.SetDWordValue("ShowInActionCenter", dwval)
-	k.Close()
+	if n.Persist {
+		// Create a key for the AppID's persistence setting.
+		k, _, _ := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\`+n.AppID, registry.ALL_ACCESS)
+		// Set the correct registry value.
+		k.SetDWordValue("ShowInActionCenter", dwval)
+		k.Close()
+	} else {
+		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\`+n.AppID, registry.ALL_ACCESS)
+	}
 
 	xml, _ := n.buildXML()
 	return invokeTemporaryScript(xml)

--- a/toast.go
+++ b/toast.go
@@ -127,7 +127,7 @@ func (n *Notification) Push() error {
 		k.SetDWordValue("ShowInActionCenter", uint32(1))
 		k.Close()
 	} else {
-		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\`+n.AppID, registry.ALL_ACCESS)
+		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\`+n.AppID)
 	}
 
 	xml, _ := n.buildXML()

--- a/toast.go
+++ b/toast.go
@@ -124,7 +124,7 @@ func (n *Notification) Push() error {
 		// Create a key for the AppID's persistence setting.
 		k, _, _ := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\`+n.AppID, registry.ALL_ACCESS)
 		// Set the correct registry value.
-		k.SetDWordValue("ShowInActionCenter", dwval)
+		k.SetDWordValue("ShowInActionCenter", uint32(1))
 		k.Close()
 	} else {
 		registry.DeleteKey(registry.CURRENT_USER, `SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings\`+n.AppID, registry.ALL_ACCESS)


### PR DESCRIPTION
Added field `Persist bool` to type `Notification` with accompanying logic in `Notification.Push()`. This determines if a toast should remain in the Action Center after it times out.

 I think some people will find this option useful. 😺 
