### PR TITLE
Malformed notification fix.

### DIFF
--- a/toast.go
+++ b/toast.go
@@ -193,7 +193,7 @@ type Action struct {
 }
 
 func (n *Notification) applyDefaults() {
-	if n.ActivationType == "" {
+	if n.ActivationType == "" && n.Actions != nil {
 		n.ActivationType = "protocol"
 	}
 	if n.Duration == "" {


### PR DESCRIPTION
If ActivationType == "protocol" and there are no Actions, the toast will be malformed and will display improperly. (ie: Title = AppID, Message = "New notification")